### PR TITLE
remove empty camera elements in ply header

### DIFF
--- a/src/Write.cpp
+++ b/src/Write.cpp
@@ -97,7 +97,9 @@ std::cout << folderPath_ << std::endl;
     fromROSMsg(*cloud, pclCloud);
 
     PLYWriter writer;
-    if (writer.write(filePath.str(), pclCloud) != 0) {
+    bool binary = false;
+    bool use_camera = false;
+    if (writer.write(filePath.str(), pclCloud, binary, use_camera) != 0) {
       ROS_ERROR("Something went wrong when trying to write the point cloud file.");
       return;
     }


### PR DESCRIPTION
PCL (by default) adds a camera header to ply files. This is typically empty in ROS and as far as I can see, there's no way in the current code that PCL can populate the details anyway. Several software packages break (e.g. cloud compare) trying to open the resulting point clouds. This fix disables camera header element generation.

Fixes https://github.com/ANYbotics/point_cloud_io/issues/6